### PR TITLE
Added Ctrl+Enter key binding for non-Vintage

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,5 +3,13 @@
         "keys": ["g", "o"],
         "command": "open_search_result",
         "context": [{"key": "setting.command_mode"}]
+    },
+    {
+        "keys": ["ctrl+enter"],
+        "command": "open_search_result",
+        "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.find-in-files" }
+        ]
     }
 ]


### PR DESCRIPTION
You may not want to add this by default as it might be more
README appropriate.

But this plugin works fantastically with this key binding for
non-Vintage users.
