### PR TITLE
fix: SublimeText 2 load of util

### DIFF
--- a/open_search_result.py
+++ b/open_search_result.py
@@ -1,6 +1,11 @@
 import os
 import sublime, sublime_plugin
-from .util import parse_line_number, is_file_path
+# Load with Python3, fallback to load with Python2
+try:
+    from .util import parse_line_number, is_file_path
+except ValueError:
+    from util import parse_line_number, is_file_path
+
 
 class OpenSearchResultKeys:
     HIGHLIGHT_ENABLED = 'highlight_search_results'


### PR DESCRIPTION
`Util.py` was not loading with the following error:

```
Writing file /C/Users/Parity/AppData/Roaming/Sublime Text 2/Packages/OpenSearchResult/open_search_result.py with encoding UTF-8
Reloading plugin C:\Users\Parity\AppData\Roaming\Sublime Text 2\Packages\OpenSearchResult\open_search_result.py
Traceback (most recent call last):
  File ".\sublime_plugin.py", line 62, in reload_plugin
    m = imp.load_module(modulename, *m_info)
  File ".\open_search_result.py", line 3, in <module>
    from .util import parse_line_number, is_file_path
ValueError: Attempted relative import in non-package
```

I have not verified this also works in ST3 -- but before pulling, you should do that.
